### PR TITLE
Fix polling not detecting completion when command scrolls out of console buffer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,15 @@ dsd-pythonanywhere is a plugin for deploying Django projects to PythonAnywhere, 
 ### Code Quality
 
 - Run ruff pre-commit hooks: `uv run pre-commit run --all-files`.
+- Typing: Always use modern Python 3.12+ typing:
+  - Use built-in generics (e.g., `list[str]`, `dict[int, str]`) instead of `typing` imports.
+  - Use the `|` operator for unions (e.g., `str | None`) instead of `Optional` or `Union`.
+  - Use `collections.abc` (e.g., `Sequence`, `Iterable`) for flexible input arguments.
+- Path Handling: Always use `pathlib.Path` for file system operations. Avoid `os.path`.
+  - Type hint paths as `pathlib.Path` for internal logic and `pathlib.Path | str` for public API entry points.
+  - Prefer path operators (e.g., `path / "subdir"`) and methods like `.read_text()` or `.write_text()`.
+
+### Agent Workflow
+
+- Always maintain a detailed todo/checklist list.
+- Always run full test suite and ruff pre-commit hooks as the last tasks in your todo list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog: dsd-pythonanywhere
 
-## 0.1 - Provisional support for deployments
+## 0.1.1
 
-### 0.1.0
+- Fix polling not detecting completion when command scrolls out of console buffer (#15)
+
+## 0.1.0
 
 - Initial testing release

--- a/dsd_pythonanywhere/client.py
+++ b/dsd_pythonanywhere/client.py
@@ -170,6 +170,12 @@ class Console:
 
         Returns: CommandResult with command and output when command is finished
         """
+        # Track whether the command has ever appeared in the output buffer.
+        # Long-running commands can produce enough output to push the original
+        # prompt line out of the buffer, so we can't rely on it still being
+        # visible when the command finally finishes.
+        command_seen = False
+
         for attempt in range(max_retries):
             log_message(
                 f"  Polling attempt {attempt + 1}: waiting for command '{expected_command}' to complete"
@@ -178,21 +184,28 @@ class Console:
             try:
                 command_run = self.get_latest_output()
                 if command_run:
-                    # First check if our command appears in the output (was echoed back)
-                    command_visible = command_run.find_most_recent_prompt_line(
-                        expected_command=expected_command
-                    )
-                    if command_visible is None:
+                    if os.getenv("DEBUG_POLLING"):
+                        log_message(f"DEBUG_POLLING raw output:\n{command_run.raw_output}")
+
+                    # Check if our command appears in the output (was echoed back)
+                    if (
+                        command_run.find_most_recent_prompt_line(expected_command=expected_command)
+                        is not None
+                    ):
+                        command_seen = True
+
+                    if not command_seen:
                         log_message("Command not yet visible in output, waiting...")
                         time.sleep(6)
                         continue
 
-                    # Command is visible, now check if it finished (empty prompt after)
+                    # Command has been seen; check if it finished (empty prompt at end)
                     if command_run.is_command_finished():
-                        command_output = command_run.extract_command_output(expected_command)
-                        if command_output is not None:
-                            log_message(f"Command '{expected_command}' completed")
-                            return CommandResult(expected_command, command_output)
+                        # extract_command_output returns None when the command line
+                        # scrolled out of the buffer; fall back to empty string
+                        command_output = command_run.extract_command_output(expected_command) or ""
+                        log_message(f"Command '{expected_command}' completed")
+                        return CommandResult(expected_command, command_output)
 
             except Exception as e:
                 log_message(f"Error polling console output: {e}")

--- a/tests/unit_tests/test_client_console.py
+++ b/tests/unit_tests/test_client_console.py
@@ -102,6 +102,50 @@ def test_wait_for_command_completion_timeout(console, mocker):
         console.wait_for_command_completion("echo test", max_retries=3)
 
 
+def test_wait_for_command_completion_scrolled_off_buffer(console, mocker):
+    """Command completing after its prompt line scrolls out of the output buffer.
+
+    Long-running commands produce enough output to push the original echo line
+    out of the console buffer.  The first poll sees the command; subsequent
+    polls no longer see it but do see an empty prompt (finished).
+    """
+    # First poll: command visible, not yet finished
+    run1 = mocker.MagicMock()
+    run1.find_most_recent_prompt_line.return_value = 0  # command still in buffer
+    run1.is_command_finished.return_value = False
+
+    # Second poll: command scrolled off buffer (returns None), but prompt is empty (finished)
+    run2 = mocker.MagicMock()
+    run2.find_most_recent_prompt_line.return_value = None  # scrolled off
+    run2.is_command_finished.return_value = True
+    run2.extract_command_output.return_value = None  # can't find it anymore
+
+    mocker.patch.object(console, "get_latest_output", side_effect=[run1, run2])
+    mocker.patch("dsd_pythonanywhere.client.time.sleep")
+
+    result = console.wait_for_command_completion("long-command", max_retries=5)
+    assert result.command == "long-command"
+    assert result.output == ""
+
+
+def test_wait_for_command_completion_debug_polling(console, mocker):
+    """DEBUG_POLLING env var causes raw output to be logged."""
+    mock_command_run = mocker.MagicMock()
+    mock_command_run.raw_output = "raw console output"
+    mock_command_run.is_command_finished.return_value = True
+    mock_command_run.extract_command_output.return_value = "output"
+    mocker.patch.object(console, "get_latest_output", return_value=mock_command_run)
+    mocker.patch("dsd_pythonanywhere.client.time.sleep")
+    mock_log = mocker.patch("dsd_pythonanywhere.client.log_message")
+    mocker.patch.dict("os.environ", {"DEBUG_POLLING": "1"})
+
+    console.wait_for_command_completion("echo test", max_retries=1)
+
+    debug_calls = [c for c in mock_log.call_args_list if "DEBUG_POLLING" in str(c)]
+    assert debug_calls, "Expected DEBUG_POLLING log message"
+    assert "raw console output" in str(debug_calls[0])
+
+
 def test_wait_for_command_completion_handles_exceptions(console, mocker):
     """wait_for_command_completion continues on exceptions."""
     # First call raises exception, second call succeeds


### PR DESCRIPTION
Polling for command completion would run indefinitely when a long-running command (e.g. the curl+bash setup script) produced enough output to push its own echoed prompt line out of the console's rolling buffer.

refs #14 