### PR TITLE
fix: avoid no-op gitignore writes

### DIFF
--- a/dsd_pythonanywhere/platform_deployer.py
+++ b/dsd_pythonanywhere/platform_deployer.py
@@ -207,10 +207,11 @@ class PlatformDeployer:
         else:
             # Append patterns to .gitignore if not already there.
             contents = gitignore_path.read_text()
-            patterns_to_add = "".join([pattern for pattern in patterns if pattern not in contents])
-            contents += f"\n{patterns_to_add}"
-            gitignore_path.write_text(contents)
-            plugin_utils.write_output(f"Added {patterns_to_add} to .gitignore")
+            patterns_to_add = "\n".join(pattern for pattern in patterns if pattern not in contents)
+            if patterns_to_add:
+                contents += f"\n{patterns_to_add}"
+                gitignore_path.write_text(contents)
+                plugin_utils.write_output(f"Added {patterns_to_add} to .gitignore")
 
     def _conclude_automate_all(self):
         """Finish automating the push to PythonAnywhere.

--- a/tests/unit_tests/test_platform_deployer.py
+++ b/tests/unit_tests/test_platform_deployer.py
@@ -32,10 +32,12 @@ def test_modify_gitignore(tmp_path: Path, monkeypatch):
     assert ".env" in contents
 
     # Test when .gitignore already contains .env
-    gitignore_path.write_text(".env\n*.pyc\n__pycache__/")
+    original_contents = ".env\n*.pyc\n__pycache__/"
+    gitignore_path.write_text(original_contents)
     deployer._modify_gitignore()
     contents = gitignore_path.read_text()
     assert contents.count(".env") == 1
+    assert contents == original_contents
 
 
 def test_modify_settings(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- leave an existing `.gitignore` unchanged when all deployment patterns are already present
- preserve the existing behavior when a missing pattern must be appended
- add a regression assertion for the trailing-newline bug

Fixes #7

## Validation

- `uv run pytest tests/unit_tests/test_platform_deployer.py::test_modify_gitignore -v`
- `uv run pytest`
- `uv run pre-commit run --all-files`
- `git diff --check`