### PR TITLE
fix: restrict allowed hosts to deployment domain

### DIFF
--- a/dsd_pythonanywhere/templates/settings.py
+++ b/dsd_pythonanywhere/templates/settings.py
@@ -17,9 +17,9 @@ if os.getenv("ON_PYTHONANYWHERE"):
     SECRET_KEY = os.getenv("SECRET_KEY")
 
     try:
-        ALLOWED_HOSTS.append("*")
+        ALLOWED_HOSTS.append("{{ deployed_project_name }}.pythonanywhere.com")
     except NameError:
-        ALLOWED_HOSTS = ["*"]
+        ALLOWED_HOSTS = ["{{ deployed_project_name }}.pythonanywhere.com"]
 
     DATABASES = {
         "default": dj_database_url.config(),

--- a/tests/unit_tests/test_platform_deployer.py
+++ b/tests/unit_tests/test_platform_deployer.py
@@ -44,6 +44,7 @@ def test_modify_settings(tmp_path: Path, monkeypatch):
     settings_content = "# Existing settings"
     settings_path.write_text(settings_content)
 
+    monkeypatch.setenv("API_USER", "testuser")
     deployer = PlatformDeployer()
     monkeypatch.setattr(dsd_config, "settings_path", settings_path)
     monkeypatch.setattr(dsd_config, "stdout", sys.stdout)
@@ -51,6 +52,7 @@ def test_modify_settings(tmp_path: Path, monkeypatch):
     deployer._modify_settings()
     modified_content = settings_path.read_text()
     assert 'if os.getenv("ON_PYTHONANYWHERE"):' in modified_content
+    assert 'ALLOWED_HOSTS = ["testuser.pythonanywhere.com"]' in modified_content
 
 
 def test_add_requirements(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Summary

- replace the wildcard `ALLOWED_HOSTS` entry with the configured PythonAnywhere deployment domain
- cover rendering the settings template for a configured API username

Fixes #6

## Validation

- `uv run pytest tests/unit_tests/test_platform_deployer.py::test_modify_settings -v`
- `uv run pytest`
- `uv run pre-commit run --all-files`
- `git diff --check`